### PR TITLE
Removed Three.js from core slice code, fracture() accept/return BufferGeometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "dev": "vite --host 127.0.0.1",
+    "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview --host 127.0.0.1",
+    "preview": "vite preview",
     "test": "jest"
   },
   "repository": {

--- a/src/fracture/Slice.ts
+++ b/src/fracture/Slice.ts
@@ -1,4 +1,5 @@
-import { Vector2, Vector3 } from "three";
+import { Vector2 } from "./utils/Vector2";
+import { Vector3 } from "./utils/Vector3";
 import { Fragment, SlicedMeshSubmesh } from "./entities/Fragment";
 import { isPointAbovePlane, linePlaneIntersection } from "./utils/MathUtils";
 import MeshVertex from "./entities/MeshVertex";

--- a/src/fracture/entities/FractureOptions.ts
+++ b/src/fracture/entities/FractureOptions.ts
@@ -1,4 +1,5 @@
-import { Vector2, Material, MeshBasicMaterial } from "three";
+import { Vector2 } from "../utils/Vector2";
+import { Material, MeshBasicMaterial } from "three";
 
 export class FractureOptions {
   /**

--- a/src/fracture/entities/MeshVertex.ts
+++ b/src/fracture/entities/MeshVertex.ts
@@ -1,9 +1,12 @@
-import { Vector2, Vector3 } from "three";
+import { Vector2 } from "../utils/Vector2";
+import { Vector3 } from "../utils/Vector3";
 
 /**
  * Data structure containing position/normal/UV data for a single vertex
  */
 export default class MeshVertex {
+  tolerance = 1e-9;
+  invTolerance = 1e9;
   position: Vector3;
   normal: Vector3;
   uv: Vector2;
@@ -23,11 +26,11 @@ export default class MeshVertex {
    * @param inverseTolerance The inverse of the tolerance used for spatial hashing
    * @returns
    */
-  hash(inverseTolerance: number = 1e6): number {
+  hash(): number {
     // Use inverse so we can multiply instead of divide to save a few ops
-    const x = Math.floor(this.position.x * inverseTolerance);
-    const y = Math.floor(this.position.y * inverseTolerance);
-    const z = Math.floor(this.position.z * inverseTolerance);
+    const x = Math.floor(this.position.x * this.invTolerance);
+    const y = Math.floor(this.position.y * this.invTolerance);
+    const z = Math.floor(this.position.z * this.invTolerance);
     const xy = 0.5 * ((x + y) * (x + y + 1)) + y; // Pairing x and y
     return (0.5 * ((xy + z) * (xy + z + 1))) / 2 + z;
   }
@@ -37,8 +40,8 @@ export default class MeshVertex {
    * @param other
    * @returns
    */
-  equals(other: MeshVertex, tolerance: number = 1e-9): boolean {
-    return this.hash(tolerance) === other.hash(tolerance);
+  equals(other: MeshVertex): boolean {
+    return this.hash() === other.hash();
   }
 
   toString(): string {

--- a/src/fracture/entities/SliceOptions.ts
+++ b/src/fracture/entities/SliceOptions.ts
@@ -1,4 +1,5 @@
-import { Material, Vector2 } from "three";
+import { Material } from "three";
+import { Vector2 } from "../utils/Vector2";
 
 export class SliceOptions {
   /**

--- a/src/fracture/entities/TriangulationPoint.ts
+++ b/src/fracture/entities/TriangulationPoint.ts
@@ -1,4 +1,4 @@
-import { Vector2 } from "three";
+import { Vector2 } from "../utils/Vector2";
 import { IBinSortable } from "../utils/BinSort";
 
 /**

--- a/src/fracture/triangulators/ConstrainedTriangulator.ts
+++ b/src/fracture/triangulators/ConstrainedTriangulator.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from "three";
+import { Vector3 } from "../utils/Vector3";
 import EdgeConstraint from "../entities/EdgeConstraint";
 import MeshVertex from "../entities/MeshVertex";
 import { Triangulator } from "./Triangulator";

--- a/src/fracture/triangulators/Triangulator.ts
+++ b/src/fracture/triangulators/Triangulator.ts
@@ -1,4 +1,5 @@
-import { Vector2, Vector3 } from "three";
+import { Vector2 } from "../utils/Vector2";
+import { Vector3 } from "../utils/Vector3";
 import TriangulationPoint from "../entities/TriangulationPoint";
 import MeshVertex from "../entities/MeshVertex";
 import { BinSort } from "../utils/BinSort";

--- a/src/fracture/utils/Box3.ts
+++ b/src/fracture/utils/Box3.ts
@@ -1,0 +1,122 @@
+import { Vector3 } from "./Vector3";
+
+export class Box3 {
+  min: Vector3;
+  max: Vector3;
+
+  constructor(
+    min: Vector3 = new Vector3(Infinity, Infinity, Infinity),
+    max: Vector3 = new Vector3(-Infinity, -Infinity, -Infinity),
+  ) {
+    this.min = min;
+    this.max = max;
+  }
+
+  set(min: Vector3, max: Vector3): this {
+    this.min.copy(min);
+    this.max.copy(max);
+    return this;
+  }
+
+  setFromPoints(points: Vector3[]): this {
+    this.makeEmpty();
+
+    for (let i = 0; i < points.length; i++) {
+      this.expandByPoint(points[i]);
+    }
+
+    return this;
+  }
+
+  makeEmpty(): this {
+    this.min.x = this.min.y = this.min.z = Infinity;
+    this.max.x = this.max.y = this.max.z = -Infinity;
+    return this;
+  }
+
+  isEmpty(): boolean {
+    return (
+      this.max.x < this.min.x ||
+      this.max.y < this.min.y ||
+      this.max.z < this.min.z
+    );
+  }
+
+  getCenter(target: Vector3): Vector3 {
+    if (this.isEmpty()) {
+      return target.set(0, 0, 0);
+    }
+    return target.copy(this.min).add(this.max).multiplyScalar(0.5);
+  }
+
+  getSize(): Vector3 {
+    return this.isEmpty()
+      ? new Vector3(0, 0, 0)
+      : new Vector3().sub(this.max).sub(this.min);
+  }
+
+  expandByPoint(point: Vector3): this {
+    this.min.x = Math.min(this.min.x, point.x);
+    this.min.y = Math.min(this.min.y, point.y);
+    this.min.z = Math.min(this.min.z, point.z);
+    this.max.x = Math.max(this.max.x, point.x);
+    this.max.y = Math.max(this.max.y, point.y);
+    this.max.z = Math.max(this.max.z, point.z);
+    return this;
+  }
+
+  expandByVector(vector: Vector3): this {
+    this.min.sub(vector);
+    this.max.add(vector);
+    return this;
+  }
+
+  expandByScalar(scalar: number): this {
+    this.min.addScalar(-scalar);
+    this.max.addScalar(scalar);
+    return this;
+  }
+
+  containsPoint(point: Vector3): boolean {
+    return !(
+      point.x < this.min.x ||
+      point.x > this.max.x ||
+      point.y < this.min.y ||
+      point.y > this.max.y ||
+      point.z < this.min.z ||
+      point.z > this.max.z
+    );
+  }
+
+  containsBox(box: Box3): boolean {
+    return (
+      this.min.x <= box.min.x &&
+      box.max.x <= this.max.x &&
+      this.min.y <= box.min.y &&
+      box.max.y <= this.max.y &&
+      this.min.z <= box.min.z &&
+      box.max.z <= this.max.z
+    );
+  }
+
+  intersectsBox(box: Box3): boolean {
+    return !(
+      box.max.x < this.min.x ||
+      box.min.x > this.max.x ||
+      box.max.y < this.min.y ||
+      box.min.y > this.max.y ||
+      box.max.z < this.min.z ||
+      box.min.z > this.max.z
+    );
+  }
+
+  clone(): Box3 {
+    return new Box3().copy(this);
+  }
+
+  copy(box: Box3): this {
+    this.min.copy(box.min);
+    this.max.copy(box.max);
+    return this;
+  }
+}

--- a/src/fracture/utils/MathUtils.ts
+++ b/src/fracture/utils/MathUtils.ts
@@ -1,4 +1,5 @@
-import { Vector2, Vector3 } from "three";
+import { Vector2 } from "./Vector2";
+import { Vector3 } from "./Vector3";
 
 /**
  * Returns true if the quad specified by the two diagonals a1->a2 and b1->b2 is convex

--- a/src/fracture/utils/Vector2.ts
+++ b/src/fracture/utils/Vector2.ts
@@ -1,0 +1,65 @@
+export class Vector2 {
+  x: number;
+  y: number;
+
+  constructor(x: number = 0, y: number = 0) {
+    this.x = x;
+    this.y = y;
+  }
+
+  set(x: number, y: number): this {
+    this.x = x;
+    this.y = y;
+    return this;
+  }
+
+  clone(): Vector2 {
+    return new Vector2(this.x, this.y);
+  }
+
+  copy(v: Vector2): this {
+    this.x = v.x;
+    this.y = v.y;
+    return this;
+  }
+
+  add(v: Vector2): this {
+    this.x += v.x;
+    this.y += v.y;
+    return this;
+  }
+
+  addScalar(s: number): this {
+    this.x += s;
+    this.y += s;
+    return this;
+  }
+
+  sub(v: Vector2): this {
+    this.x -= v.x;
+    this.y -= v.y;
+    return this;
+  }
+
+  multiplyScalar(scalar: number): this {
+    this.x *= scalar;
+    this.y *= scalar;
+    return this;
+  }
+
+  divideScalar(scalar: number): this {
+    return this.multiplyScalar(1 / scalar);
+  }
+
+  dot(v: Vector2): number {
+    return this.x * v.x + this.y * v.y;
+  }
+
+  length(): number {
+    return Math.sqrt(this.x * this.x + this.y * this.y);
+  }
+
+  normalize(): this {
+    return this.divideScalar(this.length() || 1);
+  }
+}

--- a/src/fracture/utils/Vector3.ts
+++ b/src/fracture/utils/Vector3.ts
@@ -1,0 +1,126 @@
+export class Vector3 {
+  x: number;
+  y: number;
+  z: number;
+
+  constructor(x: number = 0, y: number = 0, z: number = 0) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  set(x: number, y: number, z: number): this {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    return this;
+  }
+
+  clone(): Vector3 {
+    return new Vector3(this.x, this.y, this.z);
+  }
+
+  copy(v: Vector3): this {
+    this.x = v.x;
+    this.y = v.y;
+    this.z = v.z;
+    return this;
+  }
+
+  add(v: Vector3): this {
+    this.x += v.x;
+    this.y += v.y;
+    this.z += v.z;
+    return this;
+  }
+
+  addScalar(s: number): this {
+    this.x += s;
+    this.y += s;
+    this.z += s;
+    return this;
+  }
+
+  sub(v: Vector3): this {
+    this.x -= v.x;
+    this.y -= v.y;
+    this.z -= v.z;
+    return this;
+  }
+
+  multiplyScalar(scalar: number): this {
+    this.x *= scalar;
+    this.y *= scalar;
+    this.z *= scalar;
+    return this;
+  }
+
+  divideScalar(scalar: number): this {
+    return this.multiplyScalar(1 / scalar);
+  }
+
+  dot(v: Vector3): number {
+    return this.x * v.x + this.y * v.y + this.z * v.z;
+  }
+
+  cross(v: Vector3): this {
+    const x = this.x;
+    const y = this.y;
+    const z = this.z;
+
+    this.x = y * v.z - z * v.y;
+    this.y = z * v.x - x * v.z;
+    this.z = x * v.y - y * v.x;
+
+    return this;
+  }
+
+  length(): number {
+    return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+  }
+
+  normalize(): this {
+    return this.divideScalar(this.length() || 1);
+  }
+
+  addVectors(a: Vector3, b: Vector3): this {
+    this.x = a.x + b.x;
+    this.y = a.y + b.y;
+    this.z = a.z + b.z;
+    return this;
+  }
+
+  subVectors(a: Vector3, b: Vector3): this {
+    this.x = a.x - b.x;
+    this.y = a.y - b.y;
+    this.z = a.z - b.z;
+    return this;
+  }
+
+  crossVectors(a: Vector3, b: Vector3): this {
+    const ax = a.x;
+    const ay = a.y;
+    const az = a.z;
+
+    const bx = b.x;
+    const by = b.y;
+    const bz = b.z;
+
+    this.x = ay * bz - az * by;
+    this.y = az * bx - ax * bz;
+    this.z = ax * by - ay * bx;
+
+    return this;
+  }
+
+  negate(): this {
+    this.x = -this.x;
+    this.y = -this.y;
+    this.z = -this.z;
+    return this;
+  }
+
+  equals(v: Vector3): boolean {
+    return this.x === v.x && this.y === v.y && this.z === v.z;
+  }
+}

--- a/src/physics/BreakableObject.ts
+++ b/src/physics/BreakableObject.ts
@@ -3,7 +3,6 @@ import type * as RAPIER from "@dimforge/rapier3d";
 import { fracture } from "../fracture/Fracture";
 import { PhysicsObject } from "./PhysicsObject";
 import { FractureOptions } from "../fracture/entities/FractureOptions";
-import { Fragment } from "../fracture/entities/Fragment";
 
 type RAPIER_API = typeof import("@dimforge/rapier3d");
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import topLevelAwait from 'vite-plugin-top-level-await';
 
 /** @type {import('vite').UserConfig} */
 export default {
-  base: '/three-pinata/',
+  base: process.env.NODE_ENV === 'production' ? '/three-pinata/' : '/',
   build: {
     outDir: './dist',
     sourcemap: true,


### PR DESCRIPTION
# What Changed
Three.js has been removed from the core classes of the library. The purpose of this is so the core functionality of the library (slicing and triangulation of non-convex meshes) can be utilized in non-Three.js environments.

Additionally, `fracture()` has been updated to accept and return `THREE.BufferGeometry` objects. This should make it much more straightforward to integrate into other projects without needing to write a custom converter for `Fragment`.