### PR TITLE
Update slice() to accept BufferGeometry

### DIFF
--- a/src/fracture/Fracture.ts
+++ b/src/fracture/Fracture.ts
@@ -1,11 +1,13 @@
 import * as THREE from "three";
 import { FractureOptions } from "./entities/FractureOptions";
 import { Fragment } from "./entities/Fragment";
-import { slice } from "./Slice";
+import { sliceFragment } from "./Slice";
 import { UnionFind } from "./utils/UnionFind";
 import { Vector3 } from "./utils/Vector3";
-import MeshVertex from "./entities/MeshVertex";
-import { Vector2 } from "./utils/Vector2";
+import {
+  geometryToFragment,
+  fragmentToGeometry,
+} from "./utils/GeometryConversion";
 
 /**
  * Fractures the mesh into multiple fragments
@@ -17,58 +19,67 @@ export function fracture(
   options: FractureOptions,
 ): THREE.BufferGeometry[] {
   // We begin by fragmenting the source mesh, then process each fragment in a FIFO queue
-  // until we achieve the target fragment count.
-  let fragments = [fragmentFromGeometry(geometry)];
+  let fragments = [geometryToFragment(geometry)];
 
   // Subdivide the mesh into multiple fragments until we reach the fragment limit
   while (fragments.length < options.fragmentCount) {
     const fragment = fragments.shift()!;
     if (!fragment) continue;
 
-    fragment?.calculateBounds();
-
-    // Select an arbitrary fracture plane normal
-    const normal = new Vector3(
-      options.fracturePlanes.x ? 2.0 * Math.random() - 1 : 0,
-      options.fracturePlanes.y ? 2.0 * Math.random() - 1 : 0,
-      options.fracturePlanes.z ? 2.0 * Math.random() - 1 : 0,
-    ).normalize();
-
-    const center = new Vector3();
-    fragment.bounds.getCenter(center);
-
-    if (options.fractureMode === "Non-Convex") {
-      const { topSlice, bottomSlice } = slice(
-        fragment,
-        normal,
-        center,
-        options.textureScale,
-        options.textureOffset,
-        false,
-      );
-
-      const topfragments = findIsolatedGeometry(topSlice);
-      const bottomfragments = findIsolatedGeometry(bottomSlice);
-
-      // Check both slices for isolated fragments
-      fragments.push(...topfragments);
-      fragments.push(...bottomfragments);
-    } else {
-      const { topSlice, bottomSlice } = slice(
-        fragment,
-        normal,
-        center,
-        options.textureScale,
-        options.textureOffset,
-        true,
-      );
-
-      fragments.push(topSlice);
-      fragments.push(bottomSlice);
-    }
+    fragments.push(...fractureFragment(fragment, options));
   }
 
   return fragments.map((fragment) => fragmentToGeometry(fragment));
+}
+
+/**
+ * Fractures a single fragment into two or more pieces
+ * @param fragment The fragment to fracture
+ * @param options Options for fracturing
+ * @returns Array of resulting fragments
+ */
+export function fractureFragment(
+  fragment: Fragment,
+  options: FractureOptions,
+): Fragment[] {
+  fragment.calculateBounds();
+
+  // Select an arbitrary fracture plane normal
+  const normal = new Vector3(
+    options.fracturePlanes.x ? 2.0 * Math.random() - 1 : 0,
+    options.fracturePlanes.y ? 2.0 * Math.random() - 1 : 0,
+    options.fracturePlanes.z ? 2.0 * Math.random() - 1 : 0,
+  ).normalize();
+
+  const center = new Vector3();
+  fragment.bounds.getCenter(center);
+
+  if (options.fractureMode === "Non-Convex") {
+    const { topSlice, bottomSlice } = sliceFragment(
+      fragment,
+      normal,
+      center,
+      options.textureScale,
+      options.textureOffset,
+      false,
+    );
+
+    const topfragments = findIsolatedGeometry(topSlice);
+    const bottomfragments = findIsolatedGeometry(bottomSlice);
+
+    return [...topfragments, ...bottomfragments];
+  } else {
+    const { topSlice, bottomSlice } = sliceFragment(
+      fragment,
+      normal,
+      center,
+      options.textureScale,
+      options.textureOffset,
+      true,
+    );
+
+    return [topSlice, bottomSlice];
+  }
 }
 
 /**
@@ -177,103 +188,4 @@ function findIsolatedGeometry(fragment: Fragment): Fragment[] {
   }
 
   return Object.values(rootFragments);
-}
-
-/**
- * Converts this to a BufferGeometry object
- */
-function fragmentToGeometry(fragment: Fragment): THREE.BufferGeometry {
-  const geometry = new THREE.BufferGeometry();
-
-  const vertexCount = fragment.vertices.length + fragment.cutVertices.length;
-  const positions = new Array<number>(vertexCount * 3);
-  const normals = new Array<number>(vertexCount * 3);
-  const uvs = new Array<number>(vertexCount * 2);
-
-  let posIdx = 0;
-  let normIdx = 0;
-  let uvIdx = 0;
-
-  // Add the positions, normals and uvs for the non-cut-face geometry
-  for (const vert of fragment.vertices) {
-    positions[posIdx++] = vert.position.x;
-    positions[posIdx++] = vert.position.y;
-    positions[posIdx++] = vert.position.z;
-
-    normals[normIdx++] = vert.normal.x;
-    normals[normIdx++] = vert.normal.y;
-    normals[normIdx++] = vert.normal.z;
-
-    uvs[uvIdx++] = vert.uv.x;
-    uvs[uvIdx++] = vert.uv.y;
-  }
-
-  // Next, add the positions, normals and uvs for the cut-face geometry
-  for (const vert of fragment.cutVertices) {
-    positions[posIdx++] = vert.position.x;
-    positions[posIdx++] = vert.position.y;
-    positions[posIdx++] = vert.position.z;
-
-    normals[normIdx++] = vert.normal.x;
-    normals[normIdx++] = vert.normal.y;
-    normals[normIdx++] = vert.normal.z;
-
-    uvs[uvIdx++] = vert.uv.x;
-    uvs[uvIdx++] = vert.uv.y;
-  }
-
-  geometry.addGroup(0, fragment.triangles[0].length, 0);
-  geometry.addGroup(
-    fragment.triangles[0].length,
-    fragment.triangles[1].length,
-    1,
-  );
-
-  geometry.setAttribute(
-    "position",
-    new THREE.BufferAttribute(new Float32Array(positions), 3),
-  );
-  geometry.setAttribute(
-    "normal",
-    new THREE.BufferAttribute(new Float32Array(normals), 3),
-  );
-  geometry.setAttribute(
-    "uv",
-    new THREE.BufferAttribute(new Float32Array(uvs), 2),
-  );
-  geometry.setIndex(
-    new THREE.BufferAttribute(new Uint32Array(fragment.triangles.flat()), 1),
-  );
-
-  return geometry;
-}
-
-function fragmentFromGeometry(geometry: THREE.BufferGeometry): Fragment {
-  var positions = geometry.attributes.position.array as Float32Array;
-  var normals = geometry.attributes.normal.array as Float32Array;
-  var uvs = geometry.attributes.uv.array as Float32Array;
-
-  const data = new Fragment();
-  for (let i = 0; i < positions.length / 3; i++) {
-    const position = new Vector3(
-      positions[3 * i],
-      positions[3 * i + 1],
-      positions[3 * i + 2],
-    );
-
-    const normal = new Vector3(
-      normals[3 * i],
-      normals[3 * i + 1],
-      normals[3 * i + 2],
-    );
-
-    const uv = new Vector2(uvs[2 * i], uvs[2 * i + 1]);
-
-    data.vertices.push(new MeshVertex(position, normal, uv));
-  }
-
-  data.triangles = [Array.from(geometry.index?.array as Uint32Array), []];
-  data.calculateBounds();
-
-  return data;
 }

--- a/src/fracture/entities/EdgeConstraint.test.ts
+++ b/src/fracture/entities/EdgeConstraint.test.ts
@@ -1,4 +1,4 @@
-import EdgeConstraint from "../src/fracture/entities/EdgeConstraint";
+import EdgeConstraint from "./EdgeConstraint";
 
 describe("EdgeConstraint", () => {
   test("indentical edges are equal", () => {

--- a/src/fracture/entities/MeshVertex.test.ts
+++ b/src/fracture/entities/MeshVertex.test.ts
@@ -1,4 +1,4 @@
-import MeshVertex from "../src/fracture/entities/MeshVertex";
+import MeshVertex from "./MeshVertex";
 import { Vector3 } from "three";
 
 describe("MeshVertex", () => {

--- a/src/fracture/triangulators/ConstrainedTriangulator.test.ts
+++ b/src/fracture/triangulators/ConstrainedTriangulator.test.ts
@@ -1,7 +1,7 @@
 import { Vector2, Vector3 } from "three";
-import { ConstrainedTriangulator } from "../src/fracture/triangulators/ConstrainedTriangulator";
-import MeshVertex from "../src/fracture/entities/MeshVertex";
-import EdgeConstraint from "../src/fracture/entities/EdgeConstraint";
+import { ConstrainedTriangulator } from "./ConstrainedTriangulator";
+import MeshVertex from "../entities/MeshVertex";
+import EdgeConstraint from "../entities/EdgeConstraint";
 
 // Helper function for getting an adjacent vertex, translated to TypeScript
 function getAdjacentVertex(i: number, n: number): number {

--- a/src/fracture/triangulators/Triangulator.test.ts
+++ b/src/fracture/triangulators/Triangulator.test.ts
@@ -1,6 +1,6 @@
 import { Vector3 } from "three";
-import { Triangulator } from "../src/fracture/triangulators/Triangulator";
-import MeshVertex from "../src/fracture/entities/MeshVertex";
+import { Triangulator } from "./Triangulator";
+import MeshVertex from "../entities/MeshVertex";
 
 function getAdjacentVertex(i: number, n: number): number {
   if (i + 1 < n) {

--- a/src/fracture/utils/BinSort.test.ts
+++ b/src/fracture/utils/BinSort.test.ts
@@ -1,4 +1,4 @@
-import { BinSort, IBinSortable } from "../src/fracture/utils/BinSort";
+import { BinSort, IBinSortable } from "./BinSort";
 
 class BinnedObjectMock implements IBinSortable {
   bin: number;

--- a/src/fracture/utils/GeometryConversion.test.ts
+++ b/src/fracture/utils/GeometryConversion.test.ts
@@ -1,0 +1,114 @@
+import * as THREE from "three";
+import { geometryToFragment, fragmentToGeometry } from "./GeometryConversion";
+import { Fragment } from "../entities/Fragment";
+import { Vector2 } from "./Vector2";
+import { Vector3 } from "./Vector3";
+import MeshVertex from "../entities/MeshVertex";
+
+describe("GeometryConversion", () => {
+  let cube: THREE.BufferGeometry;
+
+  beforeEach(() => {
+    // Create a simple cube geometry for testing
+    cube = new THREE.BoxGeometry(1, 1, 1);
+  });
+
+  describe("geometryToFragment", () => {
+    it("should convert BufferGeometry to Fragment", () => {
+      const fragment = geometryToFragment(cube);
+
+      expect(fragment).toBeInstanceOf(Fragment);
+      expect(fragment.vertices.length).toBe(24); // Cube has 24 vertices (4 per face * 6 faces)
+      expect(fragment.triangles[0].length).toBe(36); // 12 triangles * 3 vertices
+      expect(fragment.triangles[1].length).toBe(0); // No cut faces yet
+    });
+
+    it("should preserve vertex attributes", () => {
+      const fragment = geometryToFragment(cube);
+      const positions = cube.attributes.position;
+      const normals = cube.attributes.normal;
+      const uvs = cube.attributes.uv;
+
+      // Check first vertex
+      expect(fragment.vertices[0].position.x).toBeCloseTo(positions.getX(0));
+      expect(fragment.vertices[0].position.y).toBeCloseTo(positions.getY(0));
+      expect(fragment.vertices[0].position.z).toBeCloseTo(positions.getZ(0));
+
+      expect(fragment.vertices[0].normal.x).toBeCloseTo(normals.getX(0));
+      expect(fragment.vertices[0].normal.y).toBeCloseTo(normals.getY(0));
+      expect(fragment.vertices[0].normal.z).toBeCloseTo(normals.getZ(0));
+
+      expect(fragment.vertices[0].uv.x).toBeCloseTo(uvs.getX(0));
+      expect(fragment.vertices[0].uv.y).toBeCloseTo(uvs.getY(0));
+    });
+  });
+
+  describe("fragmentToGeometry", () => {
+    it("should convert Fragment back to BufferGeometry", () => {
+      const fragment = new Fragment();
+
+      // Add some test vertices
+      fragment.vertices.push(
+        new MeshVertex(
+          new Vector3(0, 0, 0),
+          new Vector3(0, 1, 0),
+          new Vector2(0, 0),
+        ),
+        new MeshVertex(
+          new Vector3(1, 0, 0),
+          new Vector3(0, 1, 0),
+          new Vector2(1, 0),
+        ),
+        new MeshVertex(
+          new Vector3(0, 1, 0),
+          new Vector3(0, 1, 0),
+          new Vector2(0, 1),
+        ),
+      );
+
+      // Add a triangle
+      fragment.triangles[0] = [0, 1, 2];
+
+      const geometry = fragmentToGeometry(fragment);
+
+      expect(geometry).toBeInstanceOf(THREE.BufferGeometry);
+      expect(geometry.attributes.position.count).toBe(3);
+      expect(geometry.attributes.normal.count).toBe(3);
+      expect(geometry.attributes.uv.count).toBe(3);
+      expect(geometry.index!.count).toBe(3);
+    });
+
+    it("should handle cut faces correctly", () => {
+      const fragment = new Fragment();
+
+      // Add regular vertices
+      fragment.vertices.push(
+        new MeshVertex(
+          new Vector3(0, 0, 0),
+          new Vector3(0, 1, 0),
+          new Vector2(0, 0),
+        ),
+      );
+
+      // Add cut face vertices
+      fragment.cutVertices.push(
+        new MeshVertex(
+          new Vector3(1, 0, 0),
+          new Vector3(0, 1, 0),
+          new Vector2(1, 0),
+        ),
+      );
+
+      // Add triangles for both submeshes
+      fragment.triangles = [[0], [0]];
+
+      const geometry = fragmentToGeometry(fragment);
+
+      expect(geometry.groups.length).toBe(2);
+      expect(geometry.groups[0].start).toBe(0);
+      expect(geometry.groups[0].count).toBe(1);
+      expect(geometry.groups[1].start).toBe(1);
+      expect(geometry.groups[1].count).toBe(1);
+    });
+  });
+});

--- a/src/fracture/utils/GeometryConversion.ts
+++ b/src/fracture/utils/GeometryConversion.ts
@@ -1,0 +1,107 @@
+import * as THREE from "three";
+import { Fragment } from "../entities/Fragment";
+import { Vector2 } from "./Vector2";
+import { Vector3 } from "./Vector3";
+import MeshVertex from "../entities/MeshVertex";
+
+/**
+ * Converts a THREE.BufferGeometry to our internal Fragment representation
+ */
+export function geometryToFragment(geometry: THREE.BufferGeometry): Fragment {
+  const positions = geometry.attributes.position.array as Float32Array;
+  const normals = geometry.attributes.normal.array as Float32Array;
+  const uvs = geometry.attributes.uv.array as Float32Array;
+
+  const fragment = new Fragment();
+  for (let i = 0; i < positions.length / 3; i++) {
+    const position = new Vector3(
+      positions[3 * i],
+      positions[3 * i + 1],
+      positions[3 * i + 2],
+    );
+
+    const normal = new Vector3(
+      normals[3 * i],
+      normals[3 * i + 1],
+      normals[3 * i + 2],
+    );
+
+    const uv = new Vector2(uvs[2 * i], uvs[2 * i + 1]);
+
+    fragment.vertices.push(new MeshVertex(position, normal, uv));
+  }
+
+  fragment.triangles = [Array.from(geometry.index?.array as Uint32Array), []];
+  fragment.calculateBounds();
+
+  return fragment;
+}
+
+/**
+ * Converts our internal Fragment representation to a THREE.BufferGeometry
+ */
+export function fragmentToGeometry(fragment: Fragment): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry();
+
+  const vertexCount = fragment.vertices.length + fragment.cutVertices.length;
+  const positions = new Array<number>(vertexCount * 3);
+  const normals = new Array<number>(vertexCount * 3);
+  const uvs = new Array<number>(vertexCount * 2);
+
+  let posIdx = 0;
+  let normIdx = 0;
+  let uvIdx = 0;
+
+  // Add the positions, normals and uvs for the non-cut-face geometry
+  for (const vert of fragment.vertices) {
+    positions[posIdx++] = vert.position.x;
+    positions[posIdx++] = vert.position.y;
+    positions[posIdx++] = vert.position.z;
+
+    normals[normIdx++] = vert.normal.x;
+    normals[normIdx++] = vert.normal.y;
+    normals[normIdx++] = vert.normal.z;
+
+    uvs[uvIdx++] = vert.uv.x;
+    uvs[uvIdx++] = vert.uv.y;
+  }
+
+  // Next, add the positions, normals and uvs for the cut-face geometry
+  for (const vert of fragment.cutVertices) {
+    positions[posIdx++] = vert.position.x;
+    positions[posIdx++] = vert.position.y;
+    positions[posIdx++] = vert.position.z;
+
+    normals[normIdx++] = vert.normal.x;
+    normals[normIdx++] = vert.normal.y;
+    normals[normIdx++] = vert.normal.z;
+
+    uvs[uvIdx++] = vert.uv.x;
+    uvs[uvIdx++] = vert.uv.y;
+  }
+
+  geometry.addGroup(0, fragment.triangles[0].length, 0);
+  geometry.addGroup(
+    fragment.triangles[0].length,
+    fragment.triangles[1].length,
+    1,
+  );
+
+  geometry.setAttribute(
+    "position",
+    new THREE.BufferAttribute(new Float32Array(positions), 3),
+  );
+  geometry.setAttribute(
+    "normal",
+    new THREE.BufferAttribute(new Float32Array(normals), 3),
+  );
+  geometry.setAttribute(
+    "uv",
+    new THREE.BufferAttribute(new Float32Array(uvs), 2),
+  );
+  geometry.setIndex(
+    new THREE.BufferAttribute(new Uint32Array(fragment.triangles.flat()), 1),
+  );
+
+  return geometry;
+}

--- a/src/fracture/utils/MathUtils.test.ts
+++ b/src/fracture/utils/MathUtils.test.ts
@@ -1,5 +1,5 @@
 import { Vector2, Vector3 } from "three";
-import * as MathUtils from "../src/fracture/utils/MathUtils";
+import * as MathUtils from "./MathUtils";
 
 describe("isPointAbovePlane", () => {
   test("point above plane returns true", () => {


### PR DESCRIPTION
# What Changed?
The `slice()` function has been updated to accept and return `THREE.BufferGeometry` to simplify integration in other Three.js projects. The previous implementation has been renamed to `sliceFragment()`.